### PR TITLE
Fix Parent Drag Overriding SubView Dragging

### DIFF
--- a/Sources/SwiftUIPager/Pager.swift
+++ b/Sources/SwiftUIPager/Pager.swift
@@ -162,7 +162,7 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
 
         let wrappedView: AnyView = swipeInteractionArea == .page ? AnyView(stack) : AnyView(stack.contentShape(Rectangle()))
 
-        return wrappedView.highPriorityGesture(allowsDragging ? swipeGesture : nil, including: .all)
+        return wrappedView.highPriorityGesture(allowsDragging ? swipeGesture : nil, including: .subviews)
             .rotation3DEffect((isHorizontal ? .zero : Angle(degrees: 90)) + scrollDirectionAngle,
                               axis: (0, 0, 1))
             .sizeTrackable($size)

--- a/Sources/SwiftUIPager/Pager.swift
+++ b/Sources/SwiftUIPager/Pager.swift
@@ -162,7 +162,7 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
 
         let wrappedView: AnyView = swipeInteractionArea == .page ? AnyView(stack) : AnyView(stack.contentShape(Rectangle()))
 
-        return wrappedView.gesture(allowsDragging ? swipeGesture : nil, including: .gesture)
+        return wrappedView.highPriorityGesture(allowsDragging ? swipeGesture : nil, including: .all)
             .rotation3DEffect((isHorizontal ? .zero : Angle(degrees: 90)) + scrollDirectionAngle,
                               axis: (0, 0, 1))
             .sizeTrackable($size)

--- a/Sources/SwiftUIPager/Pager.swift
+++ b/Sources/SwiftUIPager/Pager.swift
@@ -162,7 +162,7 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
 
         let wrappedView: AnyView = swipeInteractionArea == .page ? AnyView(stack) : AnyView(stack.contentShape(Rectangle()))
 
-        return wrappedView.highPriorityGesture(allowsDragging ? swipeGesture : nil, including: .subviews)
+        return wrappedView.gesture(allowsDragging ? swipeGesture : nil, including: .gesture)
             .rotation3DEffect((isHorizontal ? .zero : Angle(degrees: 90)) + scrollDirectionAngle,
                               axis: (0, 0, 1))
             .sizeTrackable($size)

--- a/Sources/SwiftUIPager/Pager.swift
+++ b/Sources/SwiftUIPager/Pager.swift
@@ -162,7 +162,7 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
 
         let wrappedView: AnyView = swipeInteractionArea == .page ? AnyView(stack) : AnyView(stack.contentShape(Rectangle()))
 
-        return wrappedView.highPriorityGesture(allowsDragging ? swipeGesture : nil, including: .all)
+        return wrappedView.gesture(allowsDragging ? swipeGesture : nil)
             .rotation3DEffect((isHorizontal ? .zero : Angle(degrees: 90)) + scrollDirectionAngle,
                               axis: (0, 0, 1))
             .sizeTrackable($size)


### PR DESCRIPTION
Set the priority to the gesture to normal instead of highest.

Allows Pager Subview Pagers to prioritize their own drags instead of it being overridden by the parent Pager.