### PR TITLE
Feat/justified alignment

### DIFF
--- a/Example/SwiftUIPagerExample/Examples/EmbeddedExampleView.swift
+++ b/Example/SwiftUIPagerExample/Examples/EmbeddedExampleView.swift
@@ -10,11 +10,11 @@ import SwiftUI
 
 struct EmbeddedExampleView: View {
     @State var page: Int = 0
+    @State var page2: Int = 0
     var data = Array(0..<10)
 
-    var colors: [Color] = [
-        .red, .blue, .black, .gray, .purple, .green, .orange, .pink, .yellow, .white
-    ]
+
+    @State var alignment: ExamplePositionAlignment = .start
 
     var body: some View {
         NavigationView {
@@ -32,16 +32,34 @@ struct EmbeddedExampleView: View {
                         .padding(8)
                         .frame(width: min(proxy.size.height, proxy.size.width),
                                height: min(proxy.size.height, proxy.size.width))
-                            .background(Color.gray.opacity(0.2))
+                        .background(Color.gray.opacity(0.2))
 
-                        ForEach(self.colors, id: \.self) { color in
-                            Text("Some View")
-                                .foregroundColor(color)
-                                .padding()
+                        Text("Other alignments")
+                        .bold()
+                        .padding(.top, 40)
+
+                        Picker(selection: self.$alignment, label: Text("Position Alignment")) {
+                            ForEach(ExamplePositionAlignment.allCases, id: \.self) {
+                                Text($0.rawValue)
+                            }
                         }
+                        .pickerStyle(SegmentedPickerStyle())
+                        .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12))
+
+                        Pager(page: self.$page2,
+                              data: self.data,
+                              id: \.self) { page in
+                                self.pageView(page)
+                        }
+                        .alignment(PositionAlignment(alignment: self.alignment))
+                        .itemSpacing(10)
+                        .itemAspectRatio(0.8, alignment: .end)
+                        .padding(8)
+                        .frame(width: proxy.size.width, height: 300)
+                        .background(Color.gray.opacity(0.2))
                     }
                 }
-            }.navigationBarTitle("SwiftUIPager", displayMode: .inline)
+            }.navigationBarTitle("Inside a Scrollview", displayMode: .inline)
         }.navigationViewStyle(StackNavigationViewStyle())
     }
 
@@ -56,4 +74,23 @@ struct EmbeddedExampleView: View {
         .shadow(radius: 5)
     }
 
+}
+
+enum ExamplePositionAlignment: String, CaseIterable {
+    case start
+    case justified
+    case end
+}
+
+extension PositionAlignment {
+    init(alignment: ExamplePositionAlignment) {
+        switch alignment {
+            case .start:
+                self = .start(10)
+            case .end:
+                self = .end(10)
+            case .justified:
+                self = .justified(10)
+        }
+    }
 }

--- a/Sources/SwiftUIPager/Helpers/PositionAlignment.swift
+++ b/Sources/SwiftUIPager/Helpers/PositionAlignment.swift
@@ -12,6 +12,11 @@ public enum PositionAlignment {
     /// Sets the alignment to be centered
     case center
 
+    /// Sets the alignment to be centered, but first and last pages snapping to the sides with the specified insets:
+    /// - Left, Right if horizontal
+    /// - Top, Bottom if vertical
+    case justified(CGFloat)
+
     /// Sets the alignment to be at the start of the container with the specified insets:
     ///
     /// - Left, if horizontal
@@ -29,7 +34,7 @@ public enum PositionAlignment {
         switch self {
         case .center:
             return 0
-        case .end(let insets), .start(let insets):
+        case .end(let insets), .start(let insets), .justified(let insets):
             return insets
         }
     }
@@ -37,7 +42,7 @@ public enum PositionAlignment {
     /// Helper to compare `Alignment` ignoring associated values
     func equalsIgnoreValues(_ alignment: PositionAlignment) -> Bool {
         switch (self, alignment) {
-        case (.center, .center), (.start, .start), (.end, .end):
+        case (.center, .center), (.justified, .justified), (.start, .start), (.end, .end):
             return true
         default:
             return false
@@ -49,4 +54,7 @@ public enum PositionAlignment {
 
     /// Sets the alignment at the end, with 0 px of margin
     public static var end: PositionAlignment { .end(0) }
+
+    /// Sets the alignment justified, with 0 px of margin
+    public static var justified: PositionAlignment { .justified(0) }
 }

--- a/Sources/SwiftUIPager/Pager+Helper.swift
+++ b/Sources/SwiftUIPager/Pager+Helper.swift
@@ -149,22 +149,24 @@ extension Pager {
 
     /// Extra offset to complentate the alignment
     var alignmentOffset: CGFloat {
+        let indexOfPageFocused = dataDisplayed.firstIndex(where: { data.firstIndex(of: $0) == self.page }) ?? 0
+
         let offset: CGFloat
-        switch alignment {
-        case .center:
-            offset = 0
-        case .end(let insets):
+        switch (alignment, indexOfPageFocused) {
+        case (.end(let insets), _), (.justified(let insets), dataDisplayed.count - 1):
             if isVertical {
                 offset = (size.height - pageSize.height) / 2 - insets
             } else {
                 offset = (size.width - pageSize.width) / 2 - insets
             }
-        case .start(let insets):
+        case (.start(let insets), _), (.justified(let insets), 0):
             if isVertical {
                 offset = -(size.height - pageSize.height) / 2 + insets
             } else {
                 offset = -(size.width - pageSize.width) / 2 + insets
             }
+        case (.center, _), (.justified, _):
+            offset = 0
         }
 
         return offset

--- a/Sources/SwiftUIPager/Pager+Helper.swift
+++ b/Sources/SwiftUIPager/Pager+Helper.swift
@@ -175,6 +175,7 @@ extension Pager {
     /// Offset applied to `HStack` along the Y-Axis. Used to aligned the pages
     var yOffset: CGFloat {
         guard !itemAlignment.equalsIgnoreValues(.center) else { return 0 }
+        guard !itemAlignment.equalsIgnoreValues(.justified) else { return 0 }
         guard itemAspectRatio != nil || preferredItemSize != nil else { return 0 }
 
         let availableSpace = ((isHorizontal ? size.height - pageSize.height : size.width - pageSize.width) - sideInsets) / 2 - itemAlignment.insets

--- a/Tests/SwiftUIPagerTests/PositionAlignment_Tests.swift
+++ b/Tests/SwiftUIPagerTests/PositionAlignment_Tests.swift
@@ -14,6 +14,11 @@ final class PositionAlignment_Tests: XCTestCase {
         XCTAssertTrue(alignment.equalsIgnoreValues(.center))
     }
 
+    func test_GivenJustifiedAlignment_WhenEqualsIgnoreValues_ThenTrue() {
+        let alignment: PositionAlignment = .justified(10)
+        XCTAssertTrue(alignment.equalsIgnoreValues(.justified))
+    }
+
     func test_GivenEndAlignment_WhenEqualsIgnoreValues_ThenTrue() {
         let alignment: PositionAlignment = .end(10)
         XCTAssertTrue(alignment.equalsIgnoreValues(.end))
@@ -26,6 +31,11 @@ final class PositionAlignment_Tests: XCTestCase {
 
     func test_GivenAlignment_WhenEnd_ThenInsetsZero() {
         let alignment: PositionAlignment = .end
+        XCTAssertEqual(alignment.insets, 0)
+    }
+
+    func test_GivenAlignment_WhenJustified_ThenInsetsZero() {
+        let alignment: PositionAlignment = .justified
         XCTAssertEqual(alignment.insets, 0)
     }
 
@@ -51,16 +61,25 @@ final class PositionAlignment_Tests: XCTestCase {
         XCTAssertEqual(alignment.insets, insets)
     }
 
+    func test_GivenJustifiedAlignment_WhenInsets_ThenInsets() {
+        let insets: CGFloat = 15
+        let alignment: PositionAlignment = .justified(insets)
+        XCTAssertEqual(alignment.insets, insets)
+    }
+
     static var allTests = [
         ("test_GivenStartAlignment_WhenEqualsIgnoreValues_ThenTrue", test_GivenStartAlignment_WhenEqualsIgnoreValues_ThenTrue),
         ("test_GivenCenterAlignment_WhenEqualsIgnoreValues_ThenTrue", test_GivenCenterAlignment_WhenEqualsIgnoreValues_ThenTrue),
+        ("test_GivenJustifiedAlignment_WhenEqualsIgnoreValues_ThenTrue", test_GivenJustifiedAlignment_WhenEqualsIgnoreValues_ThenTrue),
         ("test_GivenEndAlignment_WhenEqualsIgnoreValues_ThenTrue", test_GivenEndAlignment_WhenEqualsIgnoreValues_ThenTrue),
         ("test_GivenAlignment_WhenStart_ThenInsetsZero", test_GivenAlignment_WhenStart_ThenInsetsZero),
         ("test_GivenAlignment_WhenEnd_ThenInsetsZero", test_GivenAlignment_WhenEnd_ThenInsetsZero),
+        ("test_GivenAlignment_WhenJustified_ThenInsetsZero", test_GivenAlignment_WhenJustified_ThenInsetsZero),
         ("test_GivenStartAlignment_WhenEqualsIgnoreValues_ThenFalse", test_GivenStartAlignment_WhenEqualsIgnoreValues_ThenFalse),
         ("test_GivenCenterAlignment_WhenInsets_ThenZero", test_GivenCenterAlignment_WhenInsets_ThenZero),
         ("test_GivenEndAlignment_WhenInsets_ThenInsets", test_GivenEndAlignment_WhenInsets_ThenInsets),
-        ("test_GivenStartAlignment_WhenInsets_ThenInsets", test_GivenStartAlignment_WhenInsets_ThenInsets)
+        ("test_GivenStartAlignment_WhenInsets_ThenInsets", test_GivenStartAlignment_WhenInsets_ThenInsets),
+        ("test_GivenJustifiedAlignment_WhenInsets_ThenInsets", test_GivenJustifiedAlignment_WhenInsets_ThenInsets)
     ]
 
 }


### PR DESCRIPTION
Hey @fermoya 

In the `PositionAlignment` options I was missing one useful option, the option to align to the start at the first page and to the end at the last page. I thought it would be fun to try to figure out how to add this to your library and I found out it was actually fairly easy. 

I'm not sure at all if this is something you would like to add, but I'm just putting this here for you to check out. Feel free to close it if you want to limit the functionality. 

![pager](https://user-images.githubusercontent.com/1330668/83769424-1e253100-a680-11ea-928a-5085ac9e93d1.gif)

I called it `justified` but feel free to rename it. Also added an example and some tests. 

