### PR TITLE
enhancement(animation): dont animate translate while dragging

### DIFF
--- a/Sources/SwiftUIPager/PagerContent.swift
+++ b/Sources/SwiftUIPager/PagerContent.swift
@@ -217,44 +217,42 @@ extension Pager.PagerContent {
     }
 
     func onDragChanged(with value: DragGesture.Value) {
-        withAnimation {
-            if self.lastDraggingValue == nil {
-                onDraggingBegan?()
-            }
-
-            let lastLocation = self.lastDraggingValue?.location ?? value.location
-            let swipeAngle = (value.location - lastLocation).angle ?? .zero
-            // Ignore swipes that aren't on the X-Axis
-            guard swipeAngle.isAlongXAxis else {
-                self.pagerModel.lastDraggingValue = value
-                return
-            }
-
-            let side = self.isHorizontal ? self.size.width : self.size.height
-            let normalizedRatio = self.allowsMultiplePagination ? 1 : (self.pageDistance / side)
-            let offsetIncrement = (value.location.x - lastLocation.x) * normalizedRatio
-
-            // If swipe hasn't started yet, ignore swipes if they didn't start on the X-Axis
-            let isTranslationInXAxis = abs(value.translation.width) > abs(value.translation.height)
-            guard self.draggingOffset != 0 || isTranslationInXAxis else {
-                return
-            }
-
-            let timeIncrement = value.time.timeIntervalSince(self.lastDraggingValue?.time ?? value.time)
-            if timeIncrement != 0 {
-                self.pagerModel.draggingVelocity = Double(offsetIncrement) / timeIncrement
-            }
-
-            var newOffset = self.draggingOffset + offsetIncrement
-            if !allowsMultiplePagination {
-                newOffset = self.direction == .forward ? max(newOffset, self.pageRatio * -self.pageDistance) : min(newOffset, self.pageRatio * self.pageDistance)
-            }
-
-            self.pagerModel.draggingOffset = newOffset
-            self.pagerModel.lastDraggingValue = value
-            self.onDraggingChanged?(Double(-self.draggingOffset / self.pageDistance))
-            self.pagerModel.objectWillChange.send()
+        if self.lastDraggingValue == nil {
+            onDraggingBegan?()
         }
+
+        let lastLocation = self.lastDraggingValue?.location ?? value.location
+        let swipeAngle = (value.location - lastLocation).angle ?? .zero
+        // Ignore swipes that aren't on the X-Axis
+        guard swipeAngle.isAlongXAxis else {
+            self.pagerModel.lastDraggingValue = value
+            return
+        }
+
+        let side = self.isHorizontal ? self.size.width : self.size.height
+        let normalizedRatio = self.allowsMultiplePagination ? 1 : (self.pageDistance / side)
+        let offsetIncrement = (value.location.x - lastLocation.x) * normalizedRatio
+
+        // If swipe hasn't started yet, ignore swipes if they didn't start on the X-Axis
+        let isTranslationInXAxis = abs(value.translation.width) > abs(value.translation.height)
+        guard self.draggingOffset != 0 || isTranslationInXAxis else {
+            return
+        }
+
+        let timeIncrement = value.time.timeIntervalSince(self.lastDraggingValue?.time ?? value.time)
+        if timeIncrement != 0 {
+            self.pagerModel.draggingVelocity = Double(offsetIncrement) / timeIncrement
+        }
+
+        var newOffset = self.draggingOffset + offsetIncrement
+        if !allowsMultiplePagination {
+            newOffset = self.direction == .forward ? max(newOffset, self.pageRatio * -self.pageDistance) : min(newOffset, self.pageRatio * self.pageDistance)
+        }
+
+        self.pagerModel.draggingOffset = newOffset
+        self.pagerModel.lastDraggingValue = value
+        self.onDraggingChanged?(Double(-self.draggingOffset / self.pageDistance))
+        self.pagerModel.objectWillChange.send()
     }
 
     func onDragGestureEnded() {


### PR DESCRIPTION
This is the continuation from the previous PR (https://github.com/fermoya/SwiftUIPager/pull/187) to target https://github.com/fermoya/SwiftUIPager/issues/157.

This change removes the `withAnimation` from the `onDragChanged` handler to directly translate drag positions instead of animating them. Please note: Indentation makes the diff appear bigger than there is actual change.