### PR TITLE
Typo: `onDragginEnded` to `onDraggingEnded` in Usage.md

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -253,7 +253,7 @@ Pager(...)
      })
 ```
 
-You can also use `onDraggingBegan`, `onDraggingChanged` and  `onDragginEnded` to keep track of the dragging.
+You can also use `onDraggingBegan`, `onDraggingChanged` and  `onDraggingEnded` to keep track of the dragging.
 
 ## Add pages on demand
 


### PR DESCRIPTION
Just fixing a small typo.  

I love this library, thanks so much for creating it!!!! Awesome work