### PR TITLE
Fix unwanted scroll when coming back to the app.

### DIFF
--- a/Sources/SwiftUIPager/PagerContent.swift
+++ b/Sources/SwiftUIPager/PagerContent.swift
@@ -201,7 +201,7 @@ extension Pager {
                 .onDeactivate(perform: {
                     if self.isDragging {
                         #if !os(tvOS)
-                        self.onDragGestureEnded()
+                        self.onDragCancelled()
                         #endif
                     }
                 })
@@ -340,6 +340,15 @@ extension Pager.PagerContent {
         } else if page != newPage {
             self.pagerModel.pageIncrement = 0
             onPageChanged?(newPage)
+        }
+    }
+
+    func onDragCancelled() {
+        withAnimation {
+            pagerModel.draggingOffset = 0
+            pagerModel.lastDraggingValue = nil
+            pagerModel.draggingVelocity = 0
+            pagerModel.objectWillChange.send()
         }
     }
 

--- a/Tests/SwiftUIPagerTests/DummyTests.swift
+++ b/Tests/SwiftUIPagerTests/DummyTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import SwiftUI
 @testable import SwiftUIPager
 
+@available(iOS 13.2, *)
 final class DummyTests: XCTestCase {
 
     func test_dummyGesturePriority() {


### PR DESCRIPTION
Replace recovery from going to background from `onDragGestureEnded` to `onDragCancelled`

This commit fixes an issue with iPhone X (and later) devices.
Leaving the app with the native gesture would trigger a page change coming back to the foreground.

