### PR TITLE
Fix alignment when using preferredItemSize

### DIFF
--- a/Sources/SwiftUIPager/Pager.swift
+++ b/Sources/SwiftUIPager/Pager.swift
@@ -245,7 +245,7 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
         pagerContent = isHorizontal ? pagerContent.horizontal(horizontalSwipeDirection) : pagerContent.vertical(verticalSwipeDirection)
 
         if let preferredItemSize = preferredItemSize {
-            pagerContent = pagerContent.preferredItemSize(preferredItemSize)
+            pagerContent = pagerContent.preferredItemSize(preferredItemSize, alignment: itemAlignment)
         }
 
         return pagerContent


### PR DESCRIPTION
Whenn using the `preferredItemSize`  modifier, the alignment was not passed down to the `pagerContent` and therefore did not work.

Please let me know if I should add any tests or you need something else :) 