### PR TITLE
Fix build issue in docs sample code

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -16,7 +16,7 @@ var items = Array(0..<10)
 var body: some View {
     Pager(page: page,
           data: items,
-          id: \.identifier,
+          id: \.self,
           content: { index in
               // create a page based on the data passed
               Text("Page: \(index)")


### PR DESCRIPTION
Change demo code to reflect https://github.com/fermoya/SwiftUIPager/issues/181#issuecomment-763894461
As is the sample code doesn't fails to build with error: `Value of type 'Int' has no member 'identifier'`