### PR TITLE
Add Pager clipped property

### DIFF
--- a/Sources/SwiftUIPager/Helpers/View+Helper.swift
+++ b/Sources/SwiftUIPager/Helpers/View+Helper.swift
@@ -18,5 +18,13 @@ extension View {
     func eraseToAny() -> AnyView {
         AnyView(self)
     }
-
+    
+    @ViewBuilder
+    func `if`<Content: View>(_ conditional: Bool, content: (Self) -> Content) -> some View {
+        if conditional {
+            content(self)
+        } else {
+            self
+        }
+    }
 }

--- a/Sources/SwiftUIPager/Pager+Buildable.swift
+++ b/Sources/SwiftUIPager/Pager+Buildable.swift
@@ -288,6 +288,13 @@ extension Pager: Buildable {
         mutating(keyPath: \.itemSpacing, value: value)
     }
 
+    /// Sets `Pager` is clipped. Defaults to `true`
+    ///
+    /// - Parameter value: if `Pager` is clipped
+    public func isClipped(_ value: Bool) -> Self {
+        mutating(keyPath: \.isClipped, value: value)
+    }
+
     /// Configures the aspect ratio of each page. This value is considered to be _width / height_.
     ///
     /// - Parameter value: aspect ratio to be applied to the page

--- a/Sources/SwiftUIPager/Pager.swift
+++ b/Sources/SwiftUIPager/Pager.swift
@@ -116,6 +116,9 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
 
     /// `true` if pages should have a 3D rotation effect
     var shouldRotate: Bool = false
+    
+    /// `true` if `Pager` is clipped
+    var isClipped: Bool = true
 
     /// Used to modify `Pager` offset outside this view
     var pageOffset: Double = 0
@@ -155,7 +158,7 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
 
     /// Callback invoked when a new page is set
     var onPageChanged: ((Int) -> Void)?
-	
+    
     /// Callback for a dragging began event
     var onDraggingBegan: (() -> Void)?
 
@@ -190,7 +193,9 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
         GeometryReader { proxy in
             self.content(for: proxy.size)
         }
-        .clipped()
+        .if(isClipped) {
+            $0.clipped()
+        }
     }
 
     func content(for size: CGSize) -> PagerContent {
@@ -250,7 +255,6 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
 
         return pagerContent
     }
-
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)


### PR DESCRIPTION
I found an issue where the top and bottom of the Pager were being clipped by default, causing problems when trying to achieve the effect seen in the video below. 

https://user-images.githubusercontent.com/4598443/229994317-7b2700fc-9e5c-460e-8a9e-53ace75cad54.mov

To fix this issue, I added a new property called isClipped to the Pager, which can be set to false to prevent the clipping.

``` swift
Pager(...).isClipped(false)
```
https://user-images.githubusercontent.com/4598443/229994359-c02fc82b-8f44-4d14-8c48-098ba1db5c39.mov

