### PR TITLE
perf: remove clipped modifier

### DIFF
--- a/Sources/SwiftUIPager/Pager.swift
+++ b/Sources/SwiftUIPager/Pager.swift
@@ -190,7 +190,7 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
         GeometryReader { proxy in
             self.content(for: proxy.size)
         }
-        .clipped()
+       // .clipped()
     }
 
     func content(for size: CGSize) -> PagerContent {


### PR DESCRIPTION
Hello.
I found that the ignoreSafeArea page content is clipped. I think it's better that let the framework users determine whether clip the page content.