### PR TITLE
Allows to enable/disable keyboard control, fixes issue of unwanted focus ring in macOS 14+

### DIFF
--- a/Sources/SwiftUIPager/Pager+Buildable.swift
+++ b/Sources/SwiftUIPager/Pager+Buildable.swift
@@ -378,5 +378,11 @@ extension Pager: Buildable {
         return mutating(keyPath: \.sideInsets, value: length ?? 8)
     }
 
+    /// Sets whether the page can be controlled by the keyboard
+    ///
+    /// - Parameter value: `true` if  keyboard control is allowed, `false`, otherwise. Defaults to `true`
+    public func allowsKeyboardControl(_ value: Bool = true) -> Self {
+        mutating(keyPath: \.allowsKeyboardControl, value: value)
+    }
+    
 }
-

--- a/Sources/SwiftUIPager/Pager.swift
+++ b/Sources/SwiftUIPager/Pager.swift
@@ -111,6 +111,9 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
     /// `true` if  `Pager` can be dragged
     var allowsDragging: Bool = true
 
+    /// `true` if  `Pager` can be controlled by the keyboard commands
+    var allowsKeyboardControl: Bool = true
+    
     /// `true` if  `Pager`interacts with the digital crown
     var allowsDigitalCrownRotation: Bool = true
 
@@ -215,7 +218,8 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
                 .padding(sideInsets)
                 .pagingAnimation(pagingAnimation)
                 .partialPagination(pageRatio)
-
+                .allowsKeyboardControl(allowsKeyboardControl)
+        
         #if !os(tvOS)
           pagerContent = pagerContent
             .swipeInteractionArea(swipeInteractionArea)
@@ -245,7 +249,7 @@ public struct Pager<Element, ID, PageView>: View  where PageView: View, Element:
         pagerContent = isHorizontal ? pagerContent.horizontal(horizontalSwipeDirection) : pagerContent.vertical(verticalSwipeDirection)
 
         if let preferredItemSize = preferredItemSize {
-            pagerContent = pagerContent.preferredItemSize(preferredItemSize, alignment: itemAlignment)
+            pagerContent = pagerContent.preferredItemSize(preferredItemSize)
         }
 
         return pagerContent

--- a/Sources/SwiftUIPager/PagerContent+Buildable.swift
+++ b/Sources/SwiftUIPager/PagerContent+Buildable.swift
@@ -70,6 +70,13 @@ extension Pager.PagerContent: Buildable {
         mutating(keyPath: \.pageRatio, value: ratio)
     }
 
+    /// Sets whether the page can be controlled by the keyboard
+    ///
+    /// - Parameter value: `true` if  keyboard control is allowed, `false`, otherwise. Defaults to `true`
+    func allowsKeyboardControl(_ allow: Bool) -> Self {
+        mutating(keyPath: \.allowsKeyboardControl, value: allow)
+    }
+    
     #if !os(tvOS)
 
     /// User can only swipe forward so in one direction

--- a/Sources/SwiftUIPager/PagerContent.swift
+++ b/Sources/SwiftUIPager/PagerContent.swift
@@ -92,6 +92,9 @@ extension Pager {
         /// `true` if  `Pager` can be dragged
         var allowsDragging: Bool = true
 
+        /// `true` if  `Pager` can be controlled by the keyboard commands
+        var allowsKeyboardControl: Bool = true
+        
         /// `true` if  `Pager`interacts with the digital crown
         var allowsDigitalCrownRotation: Bool = true
 
@@ -210,7 +213,7 @@ extension Pager {
             #endif
           
             #if os(macOS)
-            wrappedView = wrappedView
+            wrappedView = !allowsKeyboardControl ? wrappedView : wrappedView
               .focusable()
               .onMoveCommand(perform: self.onMoveCommandSent)
               .eraseToAny()
@@ -395,14 +398,10 @@ extension Pager.PagerContent {
         }
         withAnimation(animation) {
             self.pagerModel.draggingOffset = 0
-            if pageIncrement != 0 {
-                self.pagerModel.pageIncrement = pageIncrement
-            }
-            if page != newPage {
-                self.pagerModel.index = newPage
-            }
+            self.pagerModel.pageIncrement = pageIncrement
             self.pagerModel.draggingVelocity = 0
             self.pagerModel.lastDraggingValue = nil
+            self.pagerModel.index = newPage
             self.pagerModel.lastDigitalCrownPageOffset = CGFloat(pagerModel.index)
             self.pagerModel.objectWillChange.send()
             #if os(watchOS)

--- a/SwiftUIPager.podspec
+++ b/SwiftUIPager.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftUIPager"
-  s.version      = ENV['LIB_VERSION'] # pod trunk me --verbose
+  s.version      = '2.5.1'
   s.summary      = "Native pager for SwiftUI. Easily to use, easy to customize."
 
   s.description  = <<-DESC


### PR DESCRIPTION
Fixes: https://github.com/fermoya/SwiftUIPager/issues/329 by using the new modifier .allowsKeyboardControl(false)