### PR TITLE
Removed the 'return' as it was not necessary.

### DIFF
--- a/Sources/SwiftUIPager/PagerContent+Helper.swift
+++ b/Sources/SwiftUIPager/PagerContent+Helper.swift
@@ -52,7 +52,7 @@ extension Pager.PagerContent {
 
     /// `true` if `Pager` is vertical
     var isVertical: Bool {
-        return !isHorizontal
+        !isHorizontal
     }
 
     /// `pageOffset` converted to scrollable offset


### PR DESCRIPTION
# Overview
Removed the `return` as it was not necessary.

In accordance with `Swift` language specifications, having no `return` is acceptable and, in fact, recommended as it makes the code less verbose."